### PR TITLE
release: cut v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-04-27
+
 ### Added
 - `functions/_substitute.sh` (`safe_replace_token`) — perl-based placeholder
   substitution that treats values as opaque strings. Replaces `sed -i 's;__VAR__;…;g'`
@@ -60,3 +62,6 @@ on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `_usage.sh`: `-l/--docker-login` and `-k/--docker-logout` flags. They were
   parsed but never read — login/logout already happen inline in
   `_deploy.sh`.
+
+[Unreleased]: https://github.com/fichte/gpd/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/fichte/gpd/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary
Demote the `[Unreleased]` block in `CHANGELOG.md` to a dated `[1.0.0] - 2026-04-27` section and add Keep-a-Changelog comparison links at the bottom. The `[Unreleased]` header stays as an empty placeholder for the next batch.

No code changes — pure release plumbing.

## After this merges
Tag the merge commit and cut the GitHub release:

```bash
git checkout main && git pull --ff-only
git tag -a v1.0.0 -m "v1.0.0"
git push origin v1.0.0
gh release create v1.0.0 --title "v1.0.0" \
  --notes "$(awk '/^## \[1\.0\.0\]/,/^## \[/{ if (!/^## \[/ || /1\.0\.0/) print }' CHANGELOG.md)"
```

## Why 1.0.0
This baselines the gpd interface that consumers (e.g. xyxyx/cloud) already depend on:
- CLI flags (`-b -e -g -p -d -t -f -c -u -o -r -h`)
- Parent-project layout contract (`docker/{variables,template,config,final}`)
- Substitution semantics (`__VAR__` opaque, base/env/CI passes)
- Password-token contract (`__WUD_PASSWORD__`, `__PORTAINER_PASSWORD__`, `__OPENSEARCH_<USER>_PASSWORD__`, …)

Future SemVer rules from here:
- `1.x.0` for new features that don't break consumers
- `1.0.x` for bugfixes
- `2.0.0` for any contract change (flag rename, file-layout change, substitution semantics shift)

## Test plan
- [x] `bats tests/bats/` locally — 46/46 green
- [x] CI on this PR (CHANGELOG-only change, expected green)