### PR TITLE
release: cut v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-04-27
+
 ### Fixed
 - `functions/_remove_unused_images.sh`: refactor onto `run_in_target` /
   `compose_in_target`, replace BSD-incompatible `seq 0 N-1` loops with
@@ -71,5 +73,6 @@ on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   parsed but never read — login/logout already happen inline in
   `_deploy.sh`.
 
-[Unreleased]: https://github.com/fichte/gpd/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/fichte/gpd/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/fichte/gpd/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/fichte/gpd/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary
Demote the `[Unreleased]` block in `CHANGELOG.md` to a dated `[1.0.1] - 2026-04-27` section and add the new comparison link. The `[Unreleased]` header stays as an empty placeholder for the next batch.

No code changes — pure release plumbing.

## Why a patch release
v1.0.1 ships [#8](https://github.com/fichte/gpd/pull/8): a bugfix to `remove_unused_images` whose hand-rolled SSH-payload concatenation produced empty stdout on real remote hosts. The fix is internal-only — no flag/contract change — so SemVer rules call for a PATCH bump.

## After this merges
```bash
git checkout main && git pull --ff-only
git tag -a v1.0.1 -m "v1.0.1"
git push origin v1.0.1
gh release create v1.0.1 --title "v1.0.1" \
  --notes-file <(awk '/^## \[1\.0\.1\]/{p=1; next} /^## \[/{p=0} p' CHANGELOG.md | sed -e '/./,$!d')
```

## Test plan
- [x] Underlying fix verified by syntax check + bats (46/46 green)
- [ ] CI on this PR (CHANGELOG-only change, expected green)