### PR TITLE
deploy: retry registry logout on flaky network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- `functions/_deploy.sh` (`deploy_logout_from_registry`): joins the
+  retry'd flaky-network operations. `docker logout` now retries up to
+  `--retries` times with exponential backoff, same wrapper as login,
+  pull, push, and GeoIP download.
+
 ## [1.0.1] - 2026-04-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ from `<ENV>_STACK_OPENSEARCH_<USER>_PASSWORD`.
 | `-u` | `--unused`       | prune dangling/old images on the target |
 | `-c` | `--clean`        | remove the generated tree before re-generating |
 | `-o` | `--geoip-disable`| skip the GeoIP database download and nginx allow-list |
-| `-r` | `--retries=<N>`  | attempts for flaky-network ops (rsync push, registry login, image pull, GeoIP download); default 3, must be ≥ 1. Backoff between attempts is exponential (1s, 2s, 4s, …). |
+| `-r` | `--retries=<N>`  | attempts for flaky-network ops (rsync push, registry login, image pull, registry logout, GeoIP download); default 3, must be ≥ 1. Backoff between attempts is exponential (1s, 2s, 4s, …). |
 
 Combined invocations are common:
 

--- a/functions/_deploy.sh
+++ b/functions/_deploy.sh
@@ -179,8 +179,8 @@ function deploy_logout_from_registry()
 		return 0
 	fi
 
-	if ! run_in_target docker logout "${CI_REGISTRY}" >/dev/null 2>&1; then
-		echo "[GPD][DEPLOY][ERROR] logout from registry failed"
+	if ! gpd_retry "${RETRIES}" gpd_silent run_in_target docker logout "${CI_REGISTRY}"; then
+		echo "[GPD][DEPLOY][ERROR] logout from registry failed after ${RETRIES} attempts"
 		return 1
 	fi
 


### PR DESCRIPTION
## Summary
`deploy_logout_from_registry` was the only of the four registry/network operations not wrapped by `gpd_retry`. Add the same wrapper as login, pull, push, and GeoIP download — retries up to `--retries` (default 3) times with exponential backoff (1s, 2s, 4s).

## Test plan
- [x] `bash -n` clean
- [x] `bats tests/bats/` — 46/46 still green
- [ ] Real flaky-network deploy logout exercises the new path