### PR TITLE
release: cut v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-04-27
+
 ### Changed
 - `functions/_deploy.sh` (`deploy_logout_from_registry`): joins the
   retry'd flaky-network operations. `docker logout` now retries up to
@@ -79,6 +81,7 @@ on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   parsed but never read — login/logout already happen inline in
   `_deploy.sh`.
 
-[Unreleased]: https://github.com/fichte/gpd/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/fichte/gpd/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/fichte/gpd/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/fichte/gpd/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/fichte/gpd/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary
Demote `[Unreleased]` → `[1.0.2] - 2026-04-27`, add the new comparison link.

v1.0.2 ships [#10](https://github.com/fichte/gpd/pull/10): `deploy_logout_from_registry` joins the retry'd flaky-network operations.

## After this merges
```bash
git checkout main && git pull --ff-only
git tag -a v1.0.2 -m "v1.0.2"
git push origin v1.0.2
gh release create v1.0.2 --title "v1.0.2" \
  --notes-file <(awk '/^## \[1\.0\.2\]/{p=1; next} /^## \[/{p=0} p' CHANGELOG.md | sed -e '/./,$!d')
```